### PR TITLE
small typo fix

### DIFF
--- a/lib/Text/CSV_PP.pm
+++ b/lib/Text/CSV_PP.pm
@@ -1152,7 +1152,7 @@ Text::CSV_PP - Text::CSV_XS compatible pure-Perl module
 Text::CSV_PP has almost same functions of L<Text::CSV_XS> which 
 provides facilities for the composition and decomposition of
 comma-separated values. As its name suggests, L<Text::CSV_XS>
-is a XS module and Text::CSV_PP is a Puer Perl one.
+is a XS module and Text::CSV_PP is a Pure Perl one.
 
 =head1 VERSION
 


### PR DESCRIPTION
Hello! Me again :smiley: 

This tiny PR fixes a typo in the documentation. It says "*Puer Perl*" and it should read "*Pure Perl*" :)

It's very similar to [this RT ticket](https://rt.cpan.org/Ticket/Display.html?id=76124), but that was already fixed (you should close that, btw :wink:)

I hope this helps! Thanks again!