### PR TITLE
clarifying status value

### DIFF
--- a/lib/Text/CSV.pm
+++ b/lib/Text/CSV.pm
@@ -988,8 +988,8 @@ can check the flags.
 
  $status = $csv->status ();
 
-This object function returns success (or failure) of C<combine ()> or
-C<parse ()>, whichever was called more recently.
+This object function returns a true value for success and false for failure,
+for C<combine ()> or C<parse ()>, whichever was called more recently.
 
 =head2 error_input
 

--- a/lib/Text/CSV_PP.pm
+++ b/lib/Text/CSV_PP.pm
@@ -1752,8 +1752,8 @@ contained any byte in the range [\x00-\x08,\x10-\x1F,\x7F-\xFF]
 
  $status = $csv->status ();
 
-This object function returns success (or failure) of C<combine ()> or
-C<parse ()>, whichever was called more recently.
+This object function returns a true value for success and false for failure,
+for C<combine ()> or C<parse ()>, whichever was called more recently.
 
 =head2 error_input
 


### PR DESCRIPTION
Hello again :smiley_cat: 

This is yet another small PR to make sure everyone understands that "success" means "a true value" and "failure" means "a false value". From what I understood of the source code, this is what `status()` does :)

It fixes [this RT issue](https://rt.cpan.org/Public/Bug/Display.html?id=78580) which is 3 years old :scream_cat: 

Thanks again!