### PR TITLE
doc fixes for is_quoted() and is_binary()

### DIFF
--- a/lib/Text/CSV.pm
+++ b/lib/Text/CSV.pm
@@ -956,6 +956,8 @@ enclosed in C<quote_char> quotes. This might be important for data
 where C<,20070108,> is to be treated as a numeric value, and where
 C<,"20070108",> is explicitly marked as character string data.
 
+This method is only valid when L</keep_meta_info> is set to a true value.
+
 =head2 is_binary
 
   my $binary = $csv->is_binary ($column_idx);
@@ -965,6 +967,8 @@ last result of C<parse ()>.
 
 This returns a true value if the data in the indicated column
 contained any byte in the range [\x00-\x08,\x10-\x1F,\x7F-\xFF]
+
+This method is only valid when L</keep_meta_info> is set to a true value.
 
 =head2 is_missing
 

--- a/lib/Text/CSV_PP.pm
+++ b/lib/Text/CSV_PP.pm
@@ -1738,6 +1738,8 @@ enclosed in C<quote_char> quotes. This might be important for data
 where C<,20070108,> is to be treated as a numeric value, and where
 C<,"20070108",> is explicitly marked as character string data.
 
+This method is only valid when L</keep_meta_info> is set to a true value.
+
 =head2 is_binary
 
   my $binary = $csv->is_binary ($column_idx);
@@ -1747,6 +1749,8 @@ last result of C<parse ()>.
 
 This returns a true value if the data in the indicated column
 contained any byte in the range [\x00-\x08,\x10-\x1F,\x7F-\xFF]
+
+This method is only valid when L</keep_meta_info> is set to a true value.
 
 =head2 status
 


### PR DESCRIPTION
Hello! Me again :D

This PR applies the documentation improvement made in Text::CSV_XS over a year ago regarding [this open RT issue](https://rt.cpan.org/Public/Bug/Display.html?id=82590). It's a simple patch to let the user know `keep_meta_info` should be set to true for `is_quoted()` or `is_binary()` to return meaningful results.

Thanks!