### PR TITLE
documentation improvements on getline_hr_all ()

### DIFF
--- a/lib/Text/CSV.pm
+++ b/lib/Text/CSV.pm
@@ -813,6 +813,8 @@ C<getline_hr ()> will croak if called before C<column_names ()>.
 This will return a reference to a list of C<getline_hr ($io)> results.
 In this call, C<keep_meta_info> is disabled.
 
+C<getline_hr_all ()> will croak if called before C<column_names ()>.
+
 =head2 print_hr
 
  $csv->print_hr ($io, $ref);

--- a/lib/Text/CSV_PP.pm
+++ b/lib/Text/CSV_PP.pm
@@ -1595,6 +1595,8 @@ C<getline_hr ()> will croak if called before C<column_names ()>.
 This will return a reference to a list of C<getline_hr ($io)> results.
 In this call, C<keep_meta_info> is disabled.
 
+C<getline_hr_all ()> will croak if called before C<column_names ()>.
+
 =head2 column_names
 
 Set the keys that will be used in the C<getline_hr ()> calls. If no keys


### PR DESCRIPTION
Hi again!

This PR is based on the diff provided in [this RT ticket](https://rt.cpan.org/Public/Bug/Display.html?id=90325), and reminds the user that `getline_hr_all ()` needs `column_names ()` just like `getline_hr ()` does.

Hope it helps! Thanks!