### PR TITLE
perl-5.26.0 compatibility

### DIFF
--- a/t/20_file.t
+++ b/t/20_file.t
@@ -9,7 +9,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $|  = 1;

--- a/t/21_lexicalio.t
+++ b/t/21_lexicalio.t
@@ -18,7 +18,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $|  = 1;

--- a/t/22_scalario.t
+++ b/t/22_scalario.t
@@ -23,7 +23,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $/ = "\n";

--- a/t/40_misc.t
+++ b/t/40_misc.t
@@ -9,7 +9,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $| = 1;

--- a/t/45_eol.t
+++ b/t/45_eol.t
@@ -9,7 +9,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $| = 1;

--- a/t/46_eol_si.t
+++ b/t/46_eol_si.t
@@ -22,7 +22,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $| = 1;

--- a/t/50_utf8.t
+++ b/t/50_utf8.t
@@ -18,7 +18,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 my $tfn = "_50test.csv"; END { -f $tfn and unlink $tfn; }

--- a/t/51_utf8.t
+++ b/t/51_utf8.t
@@ -60,7 +60,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV", ("csv");
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 sub hexify { join " ", map { sprintf "%02x", $_ } unpack "C*", @_ }

--- a/t/55_combi.t
+++ b/t/55_combi.t
@@ -9,7 +9,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 my $csv = Text::CSV->new ({ binary => 1 });

--- a/t/65_allow.t
+++ b/t/65_allow.t
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV", ();
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 my $tfn = "_65test.csv"; END { -f $tfn and unlink $tfn; }

--- a/t/70_rt.t
+++ b/t/70_rt.t
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV", ();
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 my $tfn = "_70test.csv"; END { unlink $tfn, "_$tfn"; }

--- a/t/77_getall.t
+++ b/t/77_getall.t
@@ -9,7 +9,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $| = 1;

--- a/t/79_callbacks.t
+++ b/t/79_callbacks.t
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $| = 1;

--- a/t/80_diag.t
+++ b/t/80_diag.t
@@ -12,7 +12,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
 
     open PP, "< lib/Text/CSV_PP.pm" or die "Cannot read error messages from PP\n";
     while (<PP>) {

--- a/t/85_util.t
+++ b/t/85_util.t
@@ -23,7 +23,7 @@ BEGIN {
 
     use_ok "Text::CSV", "csv";
     require Encode;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 $| = 1;

--- a/t/90_csv.t
+++ b/t/90_csv.t
@@ -11,7 +11,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV", ("csv");
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 my $tfn  = "_90test.csv"; END { -f $tfn and unlink $tfn }

--- a/t/91_csv_cb.t
+++ b/t/91_csv_cb.t
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     use_ok "Text::CSV", ("csv");
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 my $tfn  = "_91test.csv"; END { -f $tfn and unlink $tfn }

--- a/t/rt99774.t
+++ b/t/rt99774.t
@@ -9,7 +9,7 @@ BEGIN {
     $ENV{PERL_TEXT_CSV} = 0;
     require_ok "Text::CSV";
     plan skip_all => "Cannot load Text::CSV" if $@;
-    require "t/util.pl";
+    require "./t/util.pl";
     }
 
 my $csv = Text::CSV->new ( { binary => 1, sep_char => ';', allow_whitespace => 1, quote_char => '"' } );


### PR DESCRIPTION
In Perl 5.26.0, '.' will no longer be found by default in @INC.  This patch
adjusts tests to correctly locate ./t/util.pl.

For: https://rt.cpan.org/Ticket/Display.html?id=120818