### PR TITLE
Update minimum perl version, put it to META.yml

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.00503;
+use 5.006001;
 use ExtUtils::MakeMaker;
 
 use lib qw( ./lib );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,6 +47,7 @@ EOF
 # the contents of the Makefile that is written.
 WriteMakefile(
     'NAME'		=> 'Text::CSV',
+    'MIN_PERL_VERSION' => '5.006001',
     'VERSION_FROM'	=> 'lib/Text/CSV.pm', # finds $VERSION
     'ABSTRACT_FROM' => 'lib/Text/CSV.pm', # retrieve abstract from module
     'AUTHOR'     => 'Makamaka Hannyaharamitu, E<lt>makamaka[at]cpan.orgE<gt>',

--- a/lib/Text/CSV_PP.pm
+++ b/lib/Text/CSV_PP.pm
@@ -5,7 +5,7 @@ package Text::CSV_PP;
 # Text::CSV_PP - Text::CSV_XS compatible pure-Perl module
 #
 ################################################################################
-require 5.005;
+require 5.006001;
 
 use strict;
 use Exporter ();


### PR DESCRIPTION
こんにちは！It was a pleasure to meet you in Glasgow!

Thanks for maintaining Text-CSV. I've made some work on minimum perl version for my monthly CPAN Pull Request Challenge assignment.

I've found at Kwalitee that this module doesn't specify a minimum perl version at META.YML file. This can be seen here: https://cpants.cpanauthors.org/release/ISHIGAKI/Text-CSV-1.96

I've used `perlver` command to find what is the minimum perl version. Some test files have 5.8.0 due rule `_open_scalar`. This is the highest throughout the repository.

Another issue is that CSV_PP.pm explicitly specifies 5.5.0, whereas it actually needs 5.6.0 due rule `_regex`. First commit in this PR updates both CSV_PP.pm and Makefile.pl to 5.8.0.

Second commit specifies 5.8 at Makefile.PL, which will make it appear on META.yml file. This fixes the kwalitee issue.

Please let me know if you'd rather keep it at 5.6, and use an older syntax in those test files. That should not be too difficult to implement.

Cheers!