### PR TITLE
Remove bad STDOUT mention

### DIFF
--- a/lib/Text/CSV.pm
+++ b/lib/Text/CSV.pm
@@ -1749,7 +1749,6 @@ where, in the absence of the C<out> attribute, this is a shortcut to
 
  csv (in => $aoa, out => "file.csv");
  csv (in => $aoa, out => $fh);
- csv (in => $aoa, out =>   STDOUT);
  csv (in => $aoa, out =>  *STDOUT);
  csv (in => $aoa, out => \*STDOUT);
  csv (in => $aoa, out => \my $data);


### PR DESCRIPTION
We read       "out" can be a file name  (e.g.  "file.csv"),  which will be opened for
       writing and closed when finished,  a file handle (e.g. $fh or "FH"),  a
       reference to a glob (e.g. "\*STDOUT"),  the glob itself (e.g. *STDOUT), " That's right. So I removed the invalid line.