### PR TITLE
fix improper reinitialization of $v_ref

### DIFF
--- a/lib/Text/CSV_PP.pm
+++ b/lib/Text/CSV_PP.pm
@@ -2308,7 +2308,7 @@ LOOP:
                 }
                 $fnum++;
                 return unless $v_ref;
-                $ctx->{flag} = 0;    
+                $ctx->{flag} = 0;
                 $ctx->{fld_idx}++;
             }
 
@@ -2319,6 +2319,7 @@ LOOP:
                 if ($waitingForField) {
                     if (!$spl && $ctx->{comment_str} && $ctx->{tmp} =~ /\A\Q$ctx->{comment_str}/) {
                         $ctx->{used} = $ctx->{size};
+                        $v_ref = undef;
                         $ctx->{fld_idx} = 0;
                         $seenSomething = 0;
                         next LOOP;

--- a/t/47_comment.t
+++ b/t/47_comment.t
@@ -62,7 +62,8 @@ is_deeply (csv (
     sep_char         => "|",
     headers          => "auto",
     allow_whitespace => 1,
-    comment_str      => "#"
+    comment_str      => "#",
+    strict           => 1
     ), [{ id => 42, name => "foo" }], "Last record is comment");
 
 1;


### PR DESCRIPTION
When the `comment_str` is set and the `strict` mode is enabled too the first row after the comment row fails with

\# CSV_PP ERROR: 2014 - ENF - Inconsistent number of fields @ rec 2 pos 10 field 1

The reason is an improper `fld_idx` count which is caused by an improper reinitialiazion of the `$v_ref` variable.
